### PR TITLE
Fix NotImplementedError: A UTF-8 locale is required. Got ANSI_X3.4-1968

### DIFF
--- a/inference_example.ipynb
+++ b/inference_example.ipynb
@@ -163,6 +163,9 @@
       },
       "outputs": [],
       "source": [
+        "import locale\n",
+        "locale.getpreferredencoding = lambda: \"UTF-8\"",
+        "\n",
         "!pip install gigaam[longform]"
       ]
     },


### PR DESCRIPTION
When I execute a cell I get an error
```
!pip install gigaam[longform]
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
[<ipython-input-5-321ca68b3134>](https://localhost:8080/#) in <cell line: 1>()
----> 1 get_ipython().system('pip install gigaam[longform]')

2 frames
[/usr/local/lib/python3.10/dist-packages/google/colab/_system_commands.py](https://localhost:8080/#) in _run_command(cmd, clear_streamed_output)
    166     locale_encoding = locale.getpreferredencoding()
    167     if locale_encoding != _ENCODING:
--> 168       raise NotImplementedError(
    169           'A UTF-8 locale is required. Got {}'.format(locale_encoding)
    170       )

NotImplementedError: A UTF-8 locale is required. Got ANSI_X3.4-1968
```

This request will fix this bug.