### PR TITLE
Adding local VAD model for longform transcribing + adding ability to pass custom audio data instead of filenames only

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The models were trained on publicly available Russian datasets:
    ```
 
    #### Long-form audio transcribation
-   1. Install external VAD dependencies ([pyannote.audio](https://github.com/pyannote/pyannote-audio) library) with 
+   1. Install external VAD dependencies ([pyannote.audio](https://github.com/pyannote/pyannote-audio) and [SileroVAD](https://github.com/snakers4/silero-vad) libraries) with 
       ```bash
       pip install gigaam[longform]
       ```
@@ -135,12 +135,13 @@ The models were trained on publicly available Russian datasets:
       * Generate [Hugging Face API token](https://huggingface.co/docs/hub/security-tokens)
       * Accept the conditions to access [pyannote/voice-activity-detection](https://huggingface.co/pyannote/voice-activity-detection) files and content.
       * Accept the conditions to access [pyannote/segmentation](https://huggingface.co/pyannote/segmentation) files and content.
+      * Or do not create HF token to use local SileroVAD instead of PyAnnote pipeline.
    3. Use the `model.transcribe_longform` method:
       ```python
       import os
       import gigaam
 
-      os.environ["HF_TOKEN"] = "<HF_TOKEN>"
+      os.environ["HF_TOKEN"] = "<HF_TOKEN>" # Remove this line to use SileroVAD
 
       model = gigaam.load_model("ctc")
       recognition_result = model.transcribe_longform("long_example.wav")

--- a/README_ru.md
+++ b/README_ru.md
@@ -108,7 +108,7 @@ embedding, _ = model.embed_audio(audio_path)
 
 ### Использование моделей распознавания речи (GigaAM-ASR)
 
-  #### Базовое использование - распознование речи на коротких аудиозаписях (до 30 секунд)
+  #### Базовое использование - распознавание речи на коротких аудиозаписях (до 30 секунд)
   ```python
    import gigaam
    model_name = "rnnt"  # Options: "v2_ctc" or "ctc", "v2_rnnt" or "rnnt", "v1_ctc", "v1_rnnt"
@@ -117,7 +117,7 @@ embedding, _ = model.embed_audio(audio_path)
    ```
 
   #### Распознавание речи на длинных аудиозаписях
-  1. Установите зависимости для внешней VAD-модели ([pyannote.audio](https://github.com/pyannote/pyannote-audio) library):
+  1. Установите зависимости для внешней VAD-модели (библиотеки [pyannote.audio](https://github.com/pyannote/pyannote-audio) и [SileroVAD](https://github.com/snakers4/silero-vad)) с помощью команды:
       ```bash
       pip install gigaam[longform]
       ```
@@ -125,13 +125,14 @@ embedding, _ = model.embed_audio(audio_path)
       * Сгенерируйте [Hugging Face API token](https://huggingface.co/docs/hub/security-tokens)
       * Примите условия для получения доступа к контенту [pyannote/voice-activity-detection](https://huggingface.co/pyannote/voice-activity-detection)
       * Примите условия для получения доступа к контенту [pyannote/segmentation](https://huggingface.co/pyannote/segmentation)
+      * Или не создавайте токен Hugging Face, чтобы использовать локальную SileroVAD вместо PyAnnote pipeline.
   
   3. Используйте метод ```model.transcribe_longform```:
       ```python
       import os
       import gigaam
 
-      os.environ["HF_TOKEN"] = "<HF_TOKEN>"
+      os.environ["HF_TOKEN"] = "<HF_TOKEN>" # Удалите эту строку, чтобы использовать SileroVAD
 
       model = gigaam.load_model("ctc")
       recognition_result = model.transcribe_longform("long_example.wav")

--- a/gigaam/model.py
+++ b/gigaam/model.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterable, List, Tuple, Union
 
 import hydra
 import omegaconf
@@ -45,7 +45,7 @@ class GigaAM(nn.Module):
     def _dtype(self) -> torch.dtype:
         return next(self.parameters()).dtype
 
-    def prepare_wav(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> Tuple[Tensor, Tensor]:
+    def prepare_wav(self, wav_or_file: Union[str, Tensor, ndarray, Iterable]) -> Tuple[Tensor, Tensor]:
         """
         Prepare an audio file for processing by loading it onto
         the correct device and converting its format.
@@ -57,7 +57,7 @@ class GigaAM(nn.Module):
         length = torch.full([1], wav.shape[-1], device=self._device)
         return wav, length
 
-    def embed_audio(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> Tuple[Tensor, Tensor]:
+    def embed_audio(self, wav_or_file: Union[str, Tensor, ndarray, Iterable]) -> Tuple[Tensor, Tensor]:
         """
         Extract audio representations using the GigaAM model.
         If the input is not a string, it is assumed to be an iterable object
@@ -90,7 +90,7 @@ class GigaAMASR(GigaAM):
         self.decoding = hydra.utils.instantiate(self.cfg.decoding)
 
     @torch.inference_mode()
-    def transcribe(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> str:
+    def transcribe(self, wav_or_file: Union[str, Tensor, ndarray, Iterable]) -> str:
         """
         Transcribes a short audio file into text.
         If the input is not a string, it is assumed to be an iterable object
@@ -147,7 +147,7 @@ class GigaAMASR(GigaAM):
 
     @torch.inference_mode()
     def transcribe_longform(
-        self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple], **kwargs
+        self, wav_or_file: Union[str, Tensor, ndarray, Iterable], **kwargs
     ) -> List[Dict[str, Union[str, Tuple[float, float]]]]:
         """
         Transcribes a long audio file by splitting it into segments and
@@ -186,7 +186,7 @@ class GigaAMEmo(GigaAM):
         self.head = hydra.utils.instantiate(self.cfg.head)
         self.id2name = cfg.id2name
 
-    def get_probs(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> Dict[str, float]:
+    def get_probs(self, wav_or_file: Union[str, Tensor, ndarray, Iterable]) -> Dict[str, float]:
         """
         Calculate probabilities for each emotion class based on the provided audio file.
         If the input is not a string, it is assumed to be an iterable object

--- a/gigaam/model.py
+++ b/gigaam/model.py
@@ -4,6 +4,7 @@ import hydra
 import omegaconf
 import torch
 from torch import Tensor, nn
+from numpy import ndarray
 
 from .preprocess import SAMPLE_RATE, load_audio
 from .utils import onnx_converter
@@ -44,21 +45,25 @@ class GigaAM(nn.Module):
     def _dtype(self) -> torch.dtype:
         return next(self.parameters()).dtype
 
-    def prepare_wav(self, wav_file: str) -> Tuple[Tensor, Tensor]:
+    def prepare_wav(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> Tuple[Tensor, Tensor]:
         """
         Prepare an audio file for processing by loading it onto
         the correct device and converting its format.
+        If the input is not a string, it is assumed to be an iterable object
+        containing the audio samples at 16kHz sample rate.
         """
-        wav = load_audio(wav_file)
+        wav = load_audio(wav_or_file)
         wav = wav.to(self._device).to(self._dtype).unsqueeze(0)
         length = torch.full([1], wav.shape[-1], device=self._device)
         return wav, length
 
-    def embed_audio(self, wav_file: str) -> Tuple[Tensor, Tensor]:
+    def embed_audio(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> Tuple[Tensor, Tensor]:
         """
         Extract audio representations using the GigaAM model.
+        If the input is not a string, it is assumed to be an iterable object
+        containing the audio samples at 16kHz sample rate.
         """
-        wav, length = self.prepare_wav(wav_file)
+        wav, length = self.prepare_wav(wav_or_file)
         encoded, encoded_len = self.forward(wav, length)
         return encoded, encoded_len
 
@@ -85,11 +90,13 @@ class GigaAMASR(GigaAM):
         self.decoding = hydra.utils.instantiate(self.cfg.decoding)
 
     @torch.inference_mode()
-    def transcribe(self, wav_file: str) -> str:
+    def transcribe(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> str:
         """
         Transcribes a short audio file into text.
+        If the input is not a string, it is assumed to be an iterable object
+        containing the audio samples at 16kHz sample rate.
         """
-        wav, length = self.prepare_wav(wav_file)
+        wav, length = self.prepare_wav(wav_or_file)
         if length > LONGFORM_THRESHOLD:
             raise ValueError("Too long wav file, use 'transcribe_longform' method.")
 
@@ -140,16 +147,18 @@ class GigaAMASR(GigaAM):
 
     @torch.inference_mode()
     def transcribe_longform(
-        self, wav_file: str, **kwargs
+        self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple], **kwargs
     ) -> List[Dict[str, Union[str, Tuple[float, float]]]]:
         """
         Transcribes a long audio file by splitting it into segments and
         then transcribing each segment.
+        If the input is not a string, it is assumed to be an iterable object
+        containing the audio samples at 16kHz sample rate.
         """
         from .vad_utils import segment_audio
 
         transcribed_segments = []
-        wav = load_audio(wav_file, return_format="int")
+        wav = load_audio(wav_or_file, return_format="int")
         segments, boundaries = segment_audio(
             wav, SAMPLE_RATE, device=self._device, **kwargs
         )
@@ -177,11 +186,13 @@ class GigaAMEmo(GigaAM):
         self.head = hydra.utils.instantiate(self.cfg.head)
         self.id2name = cfg.id2name
 
-    def get_probs(self, wav_file: str) -> Dict[str, float]:
+    def get_probs(self, wav_or_file: Union[str, Tensor, ndarray, List, Tuple]) -> Dict[str, float]:
         """
         Calculate probabilities for each emotion class based on the provided audio file.
+        If the input is not a string, it is assumed to be an iterable object
+        containing the audio samples at 16kHz sample rate.
         """
-        wav, length = self.prepare_wav(wav_file)
+        wav, length = self.prepare_wav(wav_or_file)
         encoded, _ = self.forward(wav, length)
         encoded_pooled = nn.functional.avg_pool1d(
             encoded, kernel_size=encoded.shape[-1]

--- a/gigaam/onnx_utils.py
+++ b/gigaam/onnx_utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Union, Tuple
+from typing import Iterable, List, Optional, Union
 
 import numpy as np
 import onnxruntime as rt
@@ -56,7 +56,7 @@ VOCAB = [
 
 
 def transcribe_sample(
-    wav_or_file: Union[str, Tensor, ndarray, List, Tuple],
+    wav_or_file: Union[str, Tensor, ndarray, Iterable],
     model_type: str,
     sessions: List[rt.InferenceSession],
     preprocessor: Optional[gigaam.preprocess.FeatureExtractor] = None,

--- a/gigaam/onnx_utils.py
+++ b/gigaam/onnx_utils.py
@@ -10,11 +10,11 @@ from torch import Tensor
 warnings.simplefilter("ignore", category=UserWarning)
 
 import gigaam
+from gigaam.preprocess import SAMPLE_RATE
 
 D_MODEL = 768
 DTYPE = np.float32
 MAX_LETTERS_PER_FRAME = 3
-SAMPLE_RATE = 16000
 FEAT_IN = 64
 PRED_HIDDEN = 320
 BLANK_IDX = 33
@@ -60,13 +60,14 @@ def transcribe_sample(
     model_type: str,
     sessions: List[rt.InferenceSession],
     preprocessor: Optional[gigaam.preprocess.FeatureExtractor] = None,
+    sample_rate: int = SAMPLE_RATE,
 ) -> str:
     if preprocessor is None:
         preprocessor = gigaam.preprocess.FeatureExtractor(SAMPLE_RATE, FEAT_IN)
 
     assert model_type in ["ctc", "rnnt"], "Only `ctc` and `rnnt` inference supported"
 
-    input_signal = gigaam.load_audio(wav_or_file)
+    input_signal = gigaam.load_audio(wav_or_file, sample_rate=sample_rate)
     input_signal = preprocessor(
         input_signal.unsqueeze(0), torch.tensor([input_signal.shape[-1]])
     )[0].numpy()

--- a/gigaam/onnx_utils.py
+++ b/gigaam/onnx_utils.py
@@ -1,9 +1,11 @@
 import warnings
-from typing import List, Optional
+from typing import List, Optional, Union, Tuple
 
 import numpy as np
 import onnxruntime as rt
 import torch
+from numpy import ndarray
+from torch import Tensor
 
 warnings.simplefilter("ignore", category=UserWarning)
 
@@ -54,7 +56,7 @@ VOCAB = [
 
 
 def transcribe_sample(
-    wav_file: str,
+    wav_or_file: Union[str, Tensor, ndarray, List, Tuple],
     model_type: str,
     sessions: List[rt.InferenceSession],
     preprocessor: Optional[gigaam.preprocess.FeatureExtractor] = None,
@@ -64,7 +66,7 @@ def transcribe_sample(
 
     assert model_type in ["ctc", "rnnt"], "Only `ctc` and `rnnt` inference supported"
 
-    input_signal = gigaam.load_audio(wav_file)
+    input_signal = gigaam.load_audio(wav_or_file)
     input_signal = preprocessor(
         input_signal.unsqueeze(0), torch.tensor([input_signal.shape[-1]])
     )[0].numpy()

--- a/gigaam/preprocess.py
+++ b/gigaam/preprocess.py
@@ -6,21 +6,22 @@ import torchaudio
 from torch import Tensor, nn, from_numpy, mean, float32, int16
 from numpy import ndarray, asarray
 
-SAMPLE_RATE = 16000
+SAMPLE_RATE = 16_000
 
 
 def load_audio(
     audio: Union[str, Tensor, ndarray, Iterable],
     sample_rate: int = SAMPLE_RATE,
     return_format: str = "float",
+    result_sample_rate: int = SAMPLE_RATE,
 ) -> Tensor:
     """
-    Load an audio file and resample it to the specified sample rate.
+    Load an audio file and resample it to the specified sample rate (16kHz by default).
     If the input is not a string (path), it is assumed to be an iterable object
-    containing audio samples with provided sample rate (16kHz by default).
+    containing audio samples with provided sample rate.
     """
     if isinstance(audio, str):
-        return load_audio_from_path(audio, sample_rate, return_format)
+        return load_audio_from_path(audio, result_sample_rate, return_format)
 
     if not isinstance(audio, Tensor):
         if not isinstance(audio, ndarray):
@@ -43,6 +44,8 @@ def load_audio(
 
     if audio.ndim != 1:
         audio = mean(audio, dim=0)
+
+    audio = torchaudio.functional.resample(audio, orig_freq=sample_rate, new_freq=result_sample_rate)
 
     if audio.dtype != float32 and return_format == "float":
         audio = audio.to(dtype=float32)

--- a/gigaam/preprocess.py
+++ b/gigaam/preprocess.py
@@ -1,5 +1,5 @@
 from subprocess import CalledProcessError, run
-from typing import Tuple, List, Union
+from typing import Iterable, Tuple, Union
 
 import torch
 import torchaudio
@@ -10,14 +10,14 @@ SAMPLE_RATE = 16000
 
 
 def load_audio(
-    audio: Union[str, Tensor, ndarray, List, Tuple],
+    audio: Union[str, Tensor, ndarray, Iterable],
     sample_rate: int = SAMPLE_RATE,
     return_format: str = "float",
 ) -> Tensor:
     """
     Load an audio file and resample it to the specified sample rate.
-    If the input is not a string, it is assumed to be an iterable object
-    containing the audio samples with provided sample rate (16kHz by default).
+    If the input is not a string (path), it is assumed to be an iterable object
+    containing audio samples with provided sample rate (16kHz by default).
     """
     if isinstance(audio, str):
         return load_audio_from_path(audio, sample_rate, return_format)
@@ -26,11 +26,11 @@ def load_audio(
         if not isinstance(audio, ndarray):
             try:
                 audio = asarray(audio)
-            except ValueError:
+            except ValueError as exc:
                 raise ValueError(
                     "Passed audio content is not convertible to numpy.ndarray!"
-                    f"Expected 1D Python list or tuple or numpy.ndarray or torch.Tensor, got {type(audio)}"
-                )
+                    f"Expected Iterable Python object or numpy.ndarray or torch.Tensor, got {type(audio)}"
+                ) from exc
 
         assert "float" in audio.dtype.name or "int" in audio.dtype.name, f"Audio should be a float or int array, got {audio.dtype} array"
 

--- a/gigaam/vad_utils.py
+++ b/gigaam/vad_utils.py
@@ -72,7 +72,7 @@ def segment_audio(
 
     segments: List[torch.Tensor] = []
     curr_duration = 0.0
-    curr_start = 0.0
+    curr_start = -1.0
     curr_end = 0.0
     boundaries: List[Tuple[float, float]] = []
 
@@ -80,6 +80,11 @@ def segment_audio(
     for segment in sad_segments.get_timeline().support():
         start = max(0, segment.start)
         end = min(len(audio) / 1000, segment.end)
+
+        if int(curr_start) == -1:
+            curr_start, curr_end, curr_duration = start, end, end - start
+            continue
+
         if (
             curr_duration > min_duration and start - curr_end > new_chunk_threshold
         ) or (curr_duration + (end - curr_end) > max_duration):

--- a/gigaam/vad_utils.py
+++ b/gigaam/vad_utils.py
@@ -35,6 +35,9 @@ def get_pipeline(device: Union[str, torch.device]) -> Pipeline:
 
 
 def get_silero_vad(device: Union[str, torch.device]):
+    """
+    Retrieves a SileroVAD model and moves it to the specified device.
+    """
     global _SILERO_MODEL
 
     if _SILERO_MODEL is None:
@@ -66,6 +69,7 @@ def segment_audio(
     """
     Segments an audio waveform into smaller chunks based on speech activity.
     The segmentation is performed using a PyAnnote voice activity detection pipeline.
+    If the HF_TOKEN environment variable is not set, the segmentation is performed using SileroVAD.
     """
 
     audio = AudioSegment(

--- a/inference_example.ipynb
+++ b/inference_example.ipynb
@@ -162,7 +162,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "Reading metadata...: 10203it [00:00, 10940.07it/s]\n"
+            "Reading metadata...: 10203it [00:00, 16512.91it/s]\n"
           ]
         },
         {
@@ -174,13 +174,12 @@
         }
       ],
       "source": [
-        "from datasets import load_dataset, Audio # HF Datasets library is required to be installed\n",
+        "from datasets import load_dataset # HF Datasets library is required to be installed\n",
         "\n",
         "dataset = load_dataset(\"mozilla-foundation/common_voice_17_0\", \"ru\", split=\"test\", streaming=True)\n",
-        "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate=16_000)) # 48kHz -> 16kHz\n",
         "\n",
         "for sample in dataset:\n",
-        "    print(model.transcribe(sample[\"audio\"][\"array\"]))\n",
+        "    print(model.transcribe(sample[\"audio\"][\"array\"], sample_rate=sample[\"audio\"][\"sampling_rate\"]))\n",
         "    break"
       ]
     },

--- a/inference_example.ipynb
+++ b/inference_example.ipynb
@@ -148,6 +148,44 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Transcribing numpy.ndarray data:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Reading metadata...: 10203it [00:00, 10940.07it/s]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "масштабы финансовоэкономического кризиса и темпы его распространения застали самых опытных специалистов мира врасплох\n"
+          ]
+        }
+      ],
+      "source": [
+        "from datasets import load_dataset, Audio # HF Datasets library is required to be installed\n",
+        "\n",
+        "dataset = load_dataset(\"mozilla-foundation/common_voice_17_0\", \"ru\", split=\"test\", streaming=True)\n",
+        "dataset = dataset.cast_column(\"audio\", Audio(sampling_rate=16_000)) # 48kHz -> 16kHz\n",
+        "\n",
+        "for sample in dataset:\n",
+        "    print(model.transcribe(sample[\"audio\"][\"array\"]))\n",
+        "    break"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "78WAYQTa14Qs"
       },
@@ -214,6 +252,49 @@
       ],
       "source": [
         "model = gigaam.load_model(\"ctc\", use_flash=False)\n",
+        "recognition_result = model.transcribe_longform(\"long_example.wav\")\n",
+        "\n",
+        "for utterance in recognition_result:\n",
+        "    transcription = utterance[\"transcription\"]\n",
+        "    start, end = utterance[\"boundaries\"]\n",
+        "    print(f\"[{gigaam.format_time(start)} - {gigaam.format_time(end)}]: {transcription}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Using SileroVAD instead of PyAnnote:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING:root:HF_TOKEN environment variable is not set so using local Silero VAD instead of PyAnnote pipeline\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[00:00:00 - 00:16:89]: вечерня отошла давно но в кельях тихо и темно уже и сам игумен строгий свои молитвы прекратил и кости ветхие склонил перекрестясь на одр убогий кругом и сон и тишина но церкви дверь отворена\n",
+            "[00:17:10 - 00:32:70]: трепещет луч лампады и тускло озаряет он и темную живопись икон и позлощенные оклады и раздается в тишине то тяжкий вздох то шепот важный и мрачно дремлет в вышине старинный свод\n",
+            "[00:33:00 - 00:49:39]: глухой и влажный стоят за клиросом чернец и грешник неподвижны оба и шепот их как глаз из гроба и грешник бледен как мертвец монах несчастный полно перестань\n",
+            "[00:49:79 - 01:05:59]: ужасна исповедь злодея заплачена тобою дань тому кто в злобе пламенея лукаво грешника блюдет и к вечной гибели ведет смирись опомнись время время раскаянье покров\n",
+            "[01:06:00 - 01:10:90]: я разрешу тебя грехов сложи мучительное бремя\n"
+          ]
+        }
+      ],
+      "source": [
+        "os.environ.pop(\"HF_TOKEN\", None)\n",
+        "\n",
+        "model = gigaam.load_model(\"rnnt\", use_flash=False)\n",
         "recognition_result = model.transcribe_longform(\"long_example.wav\")\n",
         "\n",
         "for utterance in recognition_result:\n",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
             open("requirements.txt", "r", encoding="utf-8").read()
         )
     ],
-    extras_require={"longform": ["pyannote.audio", "pydub"]},
+    extras_require={"longform": ["pyannote.audio", "pydub", "silero_vad"]},
     include_package_data=True,
 )


### PR DESCRIPTION
Hello, @georgygospodinov!

I was really interested in using of GigaAM ASR models **locally**, but found out that longform transcribing is only supported via the Pyannote pipeline with the necessity to create a HuggingFace API token, which does not really correlate with the idea of a _local_ STT system as it depends on a third party API.

My solution is to add support for the [Silero VAD](https://github.com/snakers4/silero-vad) model to perform long audio segmentation on the same device as the transcibing itself. To maintain compatibility with the original code, I simply added the local audio segmentation code to the `vad_utils.py` file, so that instead of throwing an error about missing the HF_TOKEN environment variable, the program switches to the Silero VAD model to retrieve basic speech activity intervals.

The logic of concatenating these chunks into full audio segments of 15 to 22 seconds length remained the same, except for a small bugfix regarding ignorance of the start timestamp of the very first speech chunk (the first resulting audio segment may be zero-length because the total audio length to the end of the first speech chunk exceeds the maximum segment length; there was also a [PR](https://github.com/salute-developers/GigaAM/pull/21) that probably fixed this bug at a high level; I could reproduce this bug myself when trying to transcribe a long audio starting with ~5 minutes of silence).

Since I've also been working on a project for comparing different local ASR models for the last few months, I thought that support for passing custom numpy.ndarray or torch.Tensor objects as audio sources would be great if someone wanted to transcribe some audio from already published datasets, for example in the HuggingFace Datasets format. For this purpose I modified the `load_audio` function in `preprocess.py` to load an audio from the path if the parameter is a string and to convert it to torch.Tensor otherwise. Of course, if any problems occur during the conversion, the exception will be thrown, but in my experience the script worked well for all correct audio sample arrays.

And the final feature corresponding to the last one is the optional `sample_rate` parameter, which is used to autoresample the source audio if it is not already in mono 16kHz format. In particular, I have demonstrated this in an example within `inference_example.ipynb` where I use the [Common Voice 17](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0) dataset as a source of 48kHz audio.

I've also made some minor changes to both `README.md` and `README_ru.md` to add the information about the features mentioned above, so for most non-advanced users my [fork](https://github.com/KalininVD/GigaAM-upgraded) should be easy to work with, but I'd appreciate any suggestions on how to improve my modifications.

All in all, I would be happy if you would review my PR, @georgygospodinov, thanks in advance!