### PR TITLE
Fix RNNT ONNX decoding memory leaks

### DIFF
--- a/gigaam/__init__.py
+++ b/gigaam/__init__.py
@@ -97,6 +97,33 @@ def hash_path(ckpt_path: str) -> str:
     return hashlib.md5(open(ckpt_path, "rb").read()).hexdigest()
 
 
+def _omegaconf_safe_globals():
+    from typing import Any
+
+    from omegaconf import DictConfig, ListConfig
+    from omegaconf import _utils as omegaconf_utils
+    from omegaconf import base as omegaconf_base
+    from omegaconf import nodes as omegaconf_nodes
+
+    safe = [
+        Any,
+        DictConfig,
+        ListConfig,
+    ]
+    for module in (omegaconf_base, omegaconf_nodes, omegaconf_utils):
+        for obj in vars(module).values():
+            if isinstance(obj, type) and getattr(obj, "__module__", "").startswith(
+                "omegaconf"
+            ):
+                safe.append(obj)
+    return list(dict.fromkeys(safe))
+
+
+def _load_checkpoint(ckpt_path: str):
+    with torch.serialization.safe_globals(_omegaconf_safe_globals()):
+        return torch.load(ckpt_path, map_location="cpu", weights_only=True)
+
+
 def _normalize_device(device: Optional[Union[str, torch.device]]) -> torch.device:
     """Normalize device parameter to torch.device."""
     if device is None:
@@ -138,7 +165,7 @@ def load_model(
 
     local_path = os.path.expanduser(model_name)
     if os.path.isfile(local_path):
-        finetuned = torch.load(local_path, map_location="cpu", weights_only=False)
+        finetuned = _load_checkpoint(local_path)
         base_name = finetuned["hyper_parameters"]["model_name"]
         model = load_model(
             base_name,
@@ -164,7 +191,7 @@ def load_model(
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=(FutureWarning))
-        checkpoint = torch.load(model_path, map_location="cpu", weights_only=False)
+        checkpoint = _load_checkpoint(model_path)
 
     if use_flash is not None:
         checkpoint["cfg"].encoder.flash_attn = use_flash

--- a/gigaam/decoder.py
+++ b/gigaam/decoder.py
@@ -81,6 +81,7 @@ class RNNTDecoder(nn.Module):
         self.pred_hidden = pred_hidden
         self.embed = nn.Embedding(num_classes, pred_hidden, padding_idx=self.blank_id)
         self.lstm = nn.LSTM(pred_hidden, pred_hidden, pred_rnn_layers)
+        self.register_buffer("_device_ref", torch.empty(0), persistent=False)
 
     def predict(
         self,
@@ -96,7 +97,8 @@ class RNNTDecoder(nn.Module):
             emb: Tensor = self.embed(x)
         else:
             emb = torch.zeros(
-                (batch_size, 1, self.pred_hidden), device=next(self.parameters()).device
+                (batch_size, 1, self.pred_hidden),
+                device=self._device_ref.device,
             )
         g, hid = self.lstm(emb.transpose(0, 1), state)
         return g.transpose(0, 1), hid

--- a/gigaam/decoding.py
+++ b/gigaam/decoding.py
@@ -6,6 +6,8 @@ from torch import Tensor
 
 from .decoder import CTCHead, RNNTHead
 
+DEFAULT_MAX_SYMBOLS_PER_STEP = 10
+
 
 class Tokenizer:
     """
@@ -105,7 +107,7 @@ class RNNTGreedyDecoding:
         self,
         vocabulary: List[str],
         model_path: Optional[str] = None,
-        max_symbols_per_step: int = 10,
+        max_symbols_per_step: int = DEFAULT_MAX_SYMBOLS_PER_STEP,
     ):
         self.tokenizer = Tokenizer(vocabulary, model_path)
         self.blank_id = len(self.tokenizer)
@@ -123,7 +125,10 @@ class RNNTGreedyDecoding:
         """Unpack batched (h, c) into per-sample states."""
         h, c = state
         b = h.shape[1]
-        return [(h[:, i : i + 1], c[:, i : i + 1]) for i in range(b)]
+        return [
+            (h[:, i : i + 1].contiguous(), c[:, i : i + 1].contiguous())
+            for i in range(b)
+        ]
 
     @torch.inference_mode()
     def decode(

--- a/gigaam/encoder.py
+++ b/gigaam/encoder.py
@@ -143,7 +143,7 @@ class MultiHeadAttention(nn.Module, ABC):
         """
         b = value.size(0)
         if mask is not None:
-            mask = mask.unsqueeze(1)
+            mask = mask[:, None, None, :] if mask.dim() == 2 else mask.unsqueeze(1)
             scores = scores.masked_fill(mask, -10000.0)
             attn = torch.softmax(scores, dim=-1).masked_fill(mask, 0.0)
         else:
@@ -228,7 +228,12 @@ class RotaryPositionMultiHeadAttention(MultiHeadAttention):
             scores = scores.view(b, -1, self.h * self.d_k)
             return self.linear_out(scores)
         elif self.torch_sdpa_attn:
-            attn_mask = None if mask is None else ~mask.unsqueeze(1)
+            if mask is None:
+                attn_mask = None
+            elif mask.dim() == 2:
+                attn_mask = ~mask[:, None, None, :]
+            else:
+                attn_mask = ~mask.unsqueeze(1)
             attn_output = F.scaled_dot_product_attention(
                 q,
                 k,
@@ -568,27 +573,26 @@ class ConformerEncoder(nn.Module):
         }
 
     def forward(self, audio_signal: Tensor, length: Tensor) -> Tuple[Tensor, Tensor]:
-        if not hasattr(self.pos_enc, "pe"):
-            self.pos_enc.extend_pe(self.pos_emb_max_len, audio_signal.device)
-
         audio_signal, length = self.pre_encode(
             x=audio_signal.transpose(1, 2), lengths=length
         )
 
         max_len = audio_signal.size(1)
+        self.pos_enc.extend_pe(
+            max(self.pos_emb_max_len, max_len),
+            audio_signal.device,
+        )
         audio_signal, pos_emb = self.pos_enc(x=audio_signal)
 
-        pad_mask = torch.arange(0, max_len, device=audio_signal.device).expand(
+        valid_mask = torch.arange(0, max_len, device=audio_signal.device).expand(
             length.size(0), -1
         ) < length.unsqueeze(-1)
 
         att_mask = None
         if audio_signal.shape[0] > 1:
-            att_mask = pad_mask.unsqueeze(1).repeat([1, max_len, 1])
-            att_mask = torch.logical_and(att_mask, att_mask.transpose(1, 2))
-            att_mask = ~att_mask
+            att_mask = ~valid_mask
 
-        pad_mask = ~pad_mask
+        pad_mask = ~valid_mask
 
         for layer in self.layers:
             if self.activation_checkpointing and self.training:

--- a/gigaam/onnx_utils.py
+++ b/gigaam/onnx_utils.py
@@ -10,13 +10,13 @@ import onnxruntime as rt
 import torch
 from tqdm.auto import tqdm
 
-from .decoding import Tokenizer
+from .decoding import DEFAULT_MAX_SYMBOLS_PER_STEP, Tokenizer
 from .preprocess import FeatureExtractor
 from .utils import AudioDataset
 
 warnings.simplefilter("ignore", category=UserWarning)
 
-MAX_LETTERS_PER_FRAME = 3
+DecodedHypothesis = Tuple[str, List[int], List[int]]
 
 
 def _session_float_dtype(session: rt.InferenceSession) -> np.dtype:
@@ -40,7 +40,8 @@ def _decode_ctc_batch(
     labels: np.ndarray,
     lengths: np.ndarray,
     tokenizer: Tokenizer,
-) -> List[str]:
+    return_hypotheses: bool = False,
+) -> Union[List[str], List[DecodedHypothesis]]:
     blank_id = len(tokenizer)
     b, t = labels.shape
     lengths = np.clip(np.asarray(lengths, dtype=np.int64).reshape(-1), 0, t)
@@ -51,7 +52,15 @@ def _decode_ctc_batch(
     time = np.arange(t, dtype=np.int64)[None, :]
     skip_mask &= time < lengths[:, None]
 
-    return [tokenizer.decode(labels[i][skip_mask[i]].tolist()) for i in range(b)]
+    hyps: List[DecodedHypothesis] = []
+    for i in range(b):
+        token_ids = labels[i][skip_mask[i]].tolist()
+        token_frames = np.nonzero(skip_mask[i])[0].tolist()
+        hyps.append((tokenizer.decode(token_ids), token_ids, token_frames))
+
+    if return_hypotheses:
+        return hyps
+    return [text for text, _, _ in hyps]
 
 
 def _cat_states(
@@ -67,7 +76,14 @@ def _split_state(
 ) -> List[Tuple[np.ndarray, np.ndarray]]:
     h, c = state
     b = h.shape[1]
-    return [(h[:, i : i + 1], c[:, i : i + 1]) for i in range(b)]
+    return [(h[:, i : i + 1].copy(), c[:, i : i + 1].copy()) for i in range(b)]
+
+
+def _max_symbols_per_step(model_cfg: omegaconf.DictConfig) -> int:
+    decoding_cfg = model_cfg.get("decoding")
+    if decoding_cfg is None:
+        return DEFAULT_MAX_SYMBOLS_PER_STEP
+    return int(decoding_cfg.get("max_symbols_per_step", DEFAULT_MAX_SYMBOLS_PER_STEP))
 
 
 def _decode_rnnt_batch(
@@ -76,7 +92,8 @@ def _decode_rnnt_batch(
     model_cfg: omegaconf.DictConfig,
     sessions: List[Optional[rt.InferenceSession]],
     tokenizer: Tokenizer,
-) -> List[str]:
+    return_hypotheses: bool = False,
+) -> Union[List[str], List[DecodedHypothesis]]:
     pred_sess, joint_sess = sessions[1:]
     dtype = _session_float_dtype(pred_sess)
 
@@ -87,8 +104,10 @@ def _decode_rnnt_batch(
     B, _, T = enc_features.shape
 
     hyps: List[List[int]] = [[] for _ in range(B)]
+    token_frames: List[List[int]] = [[] for _ in range(B)]
     last_label: List[Optional[np.ndarray]] = [None] * B
     dec_state: List[Optional[Tuple[np.ndarray, np.ndarray]]] = [None] * B
+    max_symbols_per_step = _max_symbols_per_step(model_cfg)
 
     def emit_batch(batch_idx: List[int], t: int, fresh: bool) -> List[int]:
         idx = np.asarray(batch_idx, dtype=np.int64)
@@ -128,6 +147,7 @@ def _decode_rnnt_batch(
             tok = int(k[p])
 
             hyps[bi].append(tok)
+            token_frames[bi].append(t)
             last_label[bi] = np.array([[tok]], dtype=np.int64)
             dec_state[bi] = hidden_parts[p]
             out.append(bi)
@@ -140,7 +160,7 @@ def _decode_rnnt_batch(
         if not active:
             break
 
-        for _ in range(MAX_LETTERS_PER_FRAME):
+        for _ in range(max_symbols_per_step):
             if not active:
                 break
 
@@ -158,7 +178,37 @@ def _decode_rnnt_batch(
 
             active = next_active
 
-    return [tokenizer.decode(h) for h in hyps]
+    decoded = [(tokenizer.decode(h), h, tf) for h, tf in zip(hyps, token_frames)]
+    if return_hypotheses:
+        return decoded
+    return [text for text, _, _ in decoded]
+
+
+def _hypotheses_to_results(
+    decoded: List[DecodedHypothesis],
+    wav_lens: torch.Tensor,
+    encoded_lens: np.ndarray,
+    tokenizer: Tokenizer,
+):
+    from .timestamps_utils import compute_frame_shift, frames_to_words
+    from .types import TranscriptionResult
+
+    encoded_lens = np.asarray(encoded_lens, dtype=np.int64).reshape(-1)
+    out = []
+    for i, (text, token_ids, token_frames) in enumerate(decoded):
+        frame_shift = compute_frame_shift(int(wav_lens[i].item()), int(encoded_lens[i]))
+        out.append(
+            TranscriptionResult(
+                text=text,
+                words=frames_to_words(
+                    tokenizer,
+                    token_ids,
+                    token_frames,
+                    frame_shift,
+                ),
+            )
+        )
+    return out
 
 
 def infer_onnx(
@@ -170,6 +220,7 @@ def infer_onnx(
     batch_size: int = 16,
     num_workers: int = 0,
     progress: bool = True,
+    word_timestamps: bool = False,
 ) -> Union[List[str], np.ndarray, List[np.ndarray]]:
     """
     Perform inference of GigaAM model with ONNX Runtime.
@@ -184,13 +235,19 @@ def infer_onnx(
     batch_size : Inference batch size.
     num_workers : Number of workers for data loading (use for large datasets).
     progress : Whether to show progress bar.
+    word_timestamps : Whether to return TranscriptionResult objects with word
+        timestamps for ASR models.
 
     Returns
     -------
     Union[List[str], np.ndarray, List[np.ndarray]]
-        List of texts (ASR) / probs (Emo) / arrays (SSL) per sample.
+        List of texts or TranscriptionResult objects with ``word_timestamps=True``
+        (ASR) / probs (Emo) / arrays (SSL) per sample.
     """
     model_name = model_cfg.model_name
+
+    if word_timestamps and not ("ctc" in model_name or "rnnt" in model_name):
+        raise ValueError("word_timestamps is supported only for ASR models")
 
     if any(s in model_name for s in ["v1", "v2", "emo"]) and batch_size > 32:
         logging.warning(
@@ -266,15 +323,27 @@ def infer_onnx(
         batch_lengths = np.asarray(batch_outputs[1], dtype=np.int64).reshape(-1)
 
         if "ctc" in model_name:
-            texts.extend(
-                _decode_ctc_batch(batch_features.argmax(-1), batch_lengths, tokenizer)
+            decoded = _decode_ctc_batch(
+                batch_features.argmax(-1),
+                batch_lengths,
+                tokenizer,
+                return_hypotheses=word_timestamps,
             )
         else:
-            texts.extend(
-                _decode_rnnt_batch(
-                    batch_features, batch_lengths, model_cfg, sessions, tokenizer
-                )
+            decoded = _decode_rnnt_batch(
+                batch_features,
+                batch_lengths,
+                model_cfg,
+                sessions,
+                tokenizer,
+                return_hypotheses=word_timestamps,
             )
+        if word_timestamps:
+            texts.extend(
+                _hypotheses_to_results(decoded, wav_lens, batch_lengths, tokenizer)
+            )
+        else:
+            texts.extend(decoded)
 
     return texts
 

--- a/gigaam/preprocess.py
+++ b/gigaam/preprocess.py
@@ -47,7 +47,7 @@ class SpecScaler(nn.Module):
     """
 
     def forward(self, x: Tensor) -> Tensor:
-        return torch.log(x.clamp_(1e-9, 1e9))
+        return torch.log(x.clamp(1e-9, 1e9))
 
 
 class FeatureExtractor(nn.Module):

--- a/gigaam/utils.py
+++ b/gigaam/utils.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import urllib.request
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -8,7 +9,6 @@ from typing import Dict, List, Optional, Tuple, Union, cast
 import numpy as np
 import soundfile as sf
 import torch
-import torch.nn.functional as F
 import torchaudio
 from torch import Tensor
 from torch.jit import TracerWarning
@@ -116,13 +116,13 @@ def apply_masked_flash_attn(
     from flash_attn import flash_attn_varlen_func
     from flash_attn.bert_padding import pad_input, unpad_input
 
-    pad_mask = ~mask[:, 0, :]
+    pad_mask = ~mask if mask.dim() == 2 else ~mask[:, 0, :]
     b, t = pad_mask.shape
     q = q.view(b, t, h * d_k)
     k = k.view(b, t, h * d_k)
     v = v.view(b, t, h * d_k)
 
-    q_unpad, indices_q, _, max_seqlen_q = unpad_input(q, pad_mask)[:4]
+    q_unpad, indices_q, cu_seqlens_q, max_seqlen_q = unpad_input(q, pad_mask)[:4]
     q_unpad = rearrange(q_unpad, "nnz (h d) -> nnz h d", h=h)
 
     k_unpad = unpad_input(k, pad_mask)[0]
@@ -130,10 +130,6 @@ def apply_masked_flash_attn(
 
     v_unpad = unpad_input(v, pad_mask)[0]
     v_unpad = rearrange(v_unpad, "nnz (h d) -> nnz h d", h=h)
-
-    lengths_q = pad_mask.sum(1).to(torch.int32).to(q.device)
-    cu_seqlens_q = F.pad(lengths_q.cumsum(0), (1, 0), value=0).to(torch.int32)
-    max_seqlen_q = torch.max(lengths_q)
 
     output_unpad = flash_attn_varlen_func(
         q_unpad,
@@ -159,8 +155,9 @@ def download_short_audio() -> str:
     """Download test audio file if not exists"""
     audio_file = "example.wav"
     if not os.path.exists(audio_file):
-        os.system(
-            'wget -O example.wav "https://cdn.chatwm.opensmodel.sberdevices.ru/GigaAM/example.wav"'
+        urllib.request.urlretrieve(
+            "https://cdn.chatwm.opensmodel.sberdevices.ru/GigaAM/example.wav",
+            audio_file,
         )
     assert os.path.exists(audio_file), "Short audio file not found"
     return audio_file
@@ -170,8 +167,9 @@ def download_long_audio() -> str:
     """Download test audio file if not exists"""
     audio_file = "long_example.wav"
     if not os.path.exists(audio_file):
-        os.system(
-            'wget -O long_example.wav "https://cdn.chatwm.opensmodel.sberdevices.ru/GigaAM/long_example.wav"'
+        urllib.request.urlretrieve(
+            "https://cdn.chatwm.opensmodel.sberdevices.ru/GigaAM/long_example.wav",
+            audio_file,
         )
     assert os.path.exists(audio_file), "Long audio file not found"
     return audio_file

--- a/gigaam/vad_utils.py
+++ b/gigaam/vad_utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import torch
 from huggingface_hub import snapshot_download
@@ -11,7 +11,7 @@ from torch.torch_version import TorchVersion
 
 from .preprocess import load_audio
 
-_PIPELINE = None
+_PIPELINES: Dict[Tuple[str, str], Pipeline] = {}
 
 
 def resolve_local_segmentation_path(model_id: str) -> str:
@@ -65,16 +65,18 @@ def get_pipeline(
     The pipeline is loaded only once and reused across subsequent calls.
     It requires the Hugging Face API token to be set in the HF_TOKEN environment variable.
     """
-    global _PIPELINE
-    if _PIPELINE is not None:
-        return _PIPELINE.to(device)
+    key = (model_id, str(device))
+    if key in _PIPELINES:
+        return _PIPELINES[key]
 
     model = load_segmentation_model(model_id=model_id)
 
-    _PIPELINE = VoiceActivityDetection(segmentation=model)
-    _PIPELINE.instantiate({"min_duration_on": 0.0, "min_duration_off": 0.0})
+    pipeline = VoiceActivityDetection(segmentation=model)
+    pipeline.instantiate({"min_duration_on": 0.0, "min_duration_off": 0.0})
+    pipeline = pipeline.to(device)
+    _PIPELINES[key] = pipeline
 
-    return _PIPELINE.to(device)
+    return pipeline
 
 
 def segment_audio_file(

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,129 @@
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+
+from gigaam.decoding import DEFAULT_MAX_SYMBOLS_PER_STEP, RNNTGreedyDecoding, Tokenizer
+from gigaam.onnx_utils import (
+    _decode_ctc_batch,
+    _decode_rnnt_batch,
+    _max_symbols_per_step,
+    _split_state as split_numpy_state,
+)
+from gigaam.preprocess import SpecScaler
+
+
+def test_rnnt_split_state_copies_torch_slices():
+    h = torch.zeros(2, 3, 4)
+    c = torch.zeros(2, 3, 4)
+
+    split = RNNTGreedyDecoding._split_state((h, c))
+    split[1][0].fill_(1.0)
+    split[1][1].fill_(1.0)
+
+    assert h.sum().item() == 0.0
+    assert c.sum().item() == 0.0
+
+
+def test_rnnt_split_state_copies_numpy_slices():
+    h = np.zeros((2, 3, 4), dtype=np.float32)
+    c = np.zeros((2, 3, 4), dtype=np.float32)
+
+    split = split_numpy_state((h, c))
+    split[1][0].fill(1.0)
+    split[1][1].fill(1.0)
+
+    assert not np.shares_memory(split[1][0], h)
+    assert not np.shares_memory(split[1][1], c)
+    assert h.sum() == 0.0
+    assert c.sum() == 0.0
+
+
+def test_onnx_rnnt_max_symbols_per_step_comes_from_config():
+    cfg = OmegaConf.create({"decoding": {"max_symbols_per_step": 7}})
+
+    assert _max_symbols_per_step(cfg) == 7
+    assert _max_symbols_per_step(OmegaConf.create({})) == DEFAULT_MAX_SYMBOLS_PER_STEP
+
+
+def test_onnx_ctc_hypotheses_include_token_frames():
+    tokenizer = Tokenizer(["a", "b"])
+    labels = np.array([[0, 0, 2, 1, 2]], dtype=np.int64)
+    lengths = np.array([5], dtype=np.int64)
+
+    decoded = _decode_ctc_batch(
+        labels,
+        lengths,
+        tokenizer,
+        return_hypotheses=True,
+    )
+
+    assert decoded == [("ab", [0, 1], [0, 3])]
+
+
+def test_onnx_rnnt_hypotheses_include_token_frames():
+    class Node:
+        def __init__(self, name, node_type="tensor(float)"):
+            self.name = name
+            self.type = node_type
+
+    class PredSession:
+        def get_inputs(self):
+            return [
+                Node("labels", "tensor(int64)"),
+                Node("h"),
+                Node("c"),
+            ]
+
+        def get_outputs(self):
+            return [Node("dec"), Node("h"), Node("c")]
+
+        def run(self, _, inputs):
+            batch = inputs["labels"].shape[0]
+            h = np.zeros((1, batch, 2), dtype=np.float32)
+            c = np.zeros((1, batch, 2), dtype=np.float32)
+            dec = np.zeros((batch, 1, 2), dtype=np.float32)
+            return [dec, h, c]
+
+    class JointSession:
+        def __init__(self):
+            self.calls = 0
+
+        def get_inputs(self):
+            return [Node("enc"), Node("dec")]
+
+        def get_outputs(self):
+            return [Node("joint")]
+
+        def run(self, _, inputs):
+            batch = inputs["enc"].shape[0]
+            logits = np.zeros((batch, 1, 1, 2), dtype=np.float32)
+            logits[:, 0, 0, 0 if self.calls == 0 else 1] = 1.0
+            self.calls += 1
+            return [logits]
+
+    cfg = OmegaConf.create(
+        {
+            "head": {"decoder": {"pred_hidden": 2, "pred_rnn_layers": 1}},
+            "decoding": {"max_symbols_per_step": 2},
+        }
+    )
+    tokenizer = Tokenizer(["a"])
+    decoded = _decode_rnnt_batch(
+        np.zeros((1, 2, 2), dtype=np.float32),
+        np.array([2], dtype=np.int64),
+        cfg,
+        [None, PredSession(), JointSession()],
+        tokenizer,
+        return_hypotheses=True,
+    )
+
+    assert decoded == [("a", [0], [0])]
+
+
+def test_spec_scaler_does_not_mutate_input():
+    x = torch.tensor([0.0, 2.0, 1e10])
+    original = x.clone()
+
+    SpecScaler()(x)
+
+    assert torch.equal(x, original)


### PR DESCRIPTION
 What changed

  - Fix RNNT state splitting so per-sample decoder state no longer keeps views into full batched LSTM states.
  - Align ONNX RNNT decoding with the torch path by using `max_symbols_per_step` from config with default `10`.
  - Return token frames from ONNX ASR decode path for timestamp support.
  - Add focused regression tests for state copying, symbol-limit config, token frames, and `SpecScaler` no-mutation behavior.
  - Include small stability fixes for long positional encodings, checkpoint loading, VAD pipeline caching, downloads, flash-attention unpadding, and decoder device lookup.

 Why

  The RNNT split helpers returned views. Keeping those views in `dec_state` could retain full `[L, B, H]` LSTM buffers for each sample and cause memory growth on long audio
  or larger batches. The ONNX decoder also had a hard-coded per-frame symbol limit of `3`, while the torch decoder defaults to `10`, which could produce different transcripts
  on the same weights.